### PR TITLE
Fix: Separate Audio Not Detected Or Managed

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,22 +1,21 @@
-// swift-tools-version: 6.0
-// The swift-tools-version declares the minimum version of Swift required to build this package.
-
+// swift-tools-version: 5.9
 import PackageDescription
 
 let package = Package(
     name: "OpenImmersive",
-    platforms: [.visionOS(.v2)],
+    platforms: [
+        .iOS(.v17), // Ensure it's set to 16.0 or newer
+        .visionOS(.v1)
+    ],
     products: [
-        // Products define the executables and libraries a package produces, making them visible to other packages.
         .library(
             name: "OpenImmersiveLib",
-            targets: ["OpenImmersive"]),
+            targets: ["OpenImmersive"]
+        ),
     ],
     targets: [
-        // Targets are the basic building blocks of a package, defining a module or a test suite.
-        // Targets can depend on other targets in this package and products from dependencies.
         .target(
-            name: "OpenImmersive"),
-
+            name: "OpenImmersive"
+        ),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,21 +1,22 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
 import PackageDescription
 
 let package = Package(
     name: "OpenImmersive",
-    platforms: [
-        .iOS(.v17), // Ensure it's set to 16.0 or newer
-        .visionOS(.v1)
-    ],
+    platforms: [.visionOS(.v2)],
     products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
         .library(
             name: "OpenImmersiveLib",
-            targets: ["OpenImmersive"]
-        ),
+            targets: ["OpenImmersive"]),
     ],
     targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
         .target(
-            name: "OpenImmersive"
-        ),
+            name: "OpenImmersive"),
+
     ]
 )

--- a/Sources/Controllers/VideoPlayer.swift
+++ b/Sources/Controllers/VideoPlayer.swift
@@ -6,7 +6,7 @@
 //
 
 import SwiftUI
-import AVFoundation
+@preconcurrency import AVFoundation
 import RealityFoundation
 
 /// Video Player Controller interfacing the underlying `AVPlayer`, exposing states and controls to the UI.

--- a/Sources/Models/AudioOption.swift
+++ b/Sources/Models/AudioOption.swift
@@ -12,15 +12,18 @@ public struct AudioOption: Codable {
     public let url: URL
     /// Language for the audio
     public let language: String
-    
+    /// The line declaring the audio option in the HLS playlist
+    public let declarationLine: String
     
     /// Public initializer for visibility.
     /// - Parameters:
     ///   - url: URL to a m3u8 HLS media playlist file.
     ///   - language: Language of the audio
-    public init(url: URL, language: String) {
+    ///   - declarationLine: The line used to declare the audio option
+    public init(url: URL, language: String, declarationLine: String) {
         self.url = url
         self.language = language
+        self.declarationLine = declarationLine
     }
     
     /// A textual description of the Resolution Option.

--- a/Sources/Models/AudioOption.swift
+++ b/Sources/Models/AudioOption.swift
@@ -1,0 +1,94 @@
+//
+//  AudioOption.swift
+//  OpenImmersive
+//
+//  Created by Zachary Handshoe on 2/23/25.
+//
+import Foundation
+
+/// Simple structure describing an audio option for an HLS video stream.
+public struct AudioOption: Codable {
+    /// URL to a m3u8 HLS media playlist file.
+    public let url: URL
+    /// Language for the audio
+    public let language: String
+    
+    
+    /// Public initializer for visibility.
+    /// - Parameters:
+    ///   - url: URL to a m3u8 HLS media playlist file.
+    ///   - language: Language of the audio
+    public init(url: URL, language: String) {
+        self.url = url
+        self.language = language
+    }
+    
+    /// A textual description of the Resolution Option.
+    public var description: String {
+        "\(languageString)"
+    }
+    
+    /// A string value for the Language.
+       public var languageString: String {
+           switch language {
+           case "en": return "English"
+           case "es": return "Spanish"
+           case "fr": return "French"
+           case "de": return "German"
+           case "it": return "Italian"
+           case "pt": return "Portuguese"
+           case "zh": return "Chinese"
+           case "ja": return "Japanese"
+           case "ko": return "Korean"
+           case "ru": return "Russian"
+           case "ar": return "Arabic"
+           case "hi": return "Hindi"
+           case "nl": return "Dutch"
+           case "sv": return "Swedish"
+           case "no": return "Norwegian"
+           case "da": return "Danish"
+           case "fi": return "Finnish"
+           case "pl": return "Polish"
+           case "tr": return "Turkish"
+           case "he": return "Hebrew"
+           case "id": return "Indonesian"
+           case "th": return "Thai"
+           case "vi": return "Vietnamese"
+           case "cs": return "Czech"
+           case "hu": return "Hungarian"
+           case "el": return "Greek"
+           case "ro": return "Romanian"
+           case "bg": return "Bulgarian"
+           case "uk": return "Ukrainian"
+           case "ms": return "Malay"
+           case "fa": return "Persian"
+           case "sr": return "Serbian"
+           case "hr": return "Croatian"
+           case "sk": return "Slovak"
+           case "sl": return "Slovenian"
+           case "lt": return "Lithuanian"
+           case "lv": return "Latvian"
+           case "et": return "Estonian"
+           default: return "Unknown"
+           }
+       }
+}
+
+extension AudioOption: Identifiable {
+    public var id: String { url.absoluteString }
+}
+
+extension AudioOption: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(language)
+        hasher.combine(url)
+    }
+}
+
+extension AudioOption: Equatable {
+    public static func == (lhs: AudioOption, rhs: AudioOption) -> Bool {
+        return lhs.id == rhs.id &&
+               lhs.language == rhs.language &&
+               lhs.url == rhs.url
+    }
+}

--- a/Sources/Models/ResolutionOption.swift
+++ b/Sources/Models/ResolutionOption.swift
@@ -16,15 +16,19 @@ public struct ResolutionOption: Codable {
     /// URL to a m3u8 HLS media playlist file.
     public let url: URL
     
+    /// The line used to declare the resolution option in the HLS playlist
+    public let declarationLine: String
+    
     /// Public initializer for visibility.
     /// - Parameters:
     ///   - size: the pixel resolution of the video stream.
     ///   - bitrate: the peak bitrate of the video stream.
     ///   - url: URL to a m3u8 HLS media playlist file.
-    public init(size: CGSize, bitrate: Int, url: URL) {
+    public init(size: CGSize, bitrate: Int, url: URL, declarationLine: String) {
         self.size = size
         self.bitrate = bitrate
         self.url = url
+        self.declarationLine = declarationLine
     }
     
     /// A textual description of the Resolution Option.

--- a/Sources/Utils/PlaylistReader.swift
+++ b/Sources/Utils/PlaylistReader.swift
@@ -162,7 +162,6 @@ public actor PlaylistReader {
     /// Parses a list of Audio Options from
     /// - Parameter text: text to be parsed, expected to be the contents of an HLS m3u8 playlist file.
     /// - Returns: a list of Audio Options.
-
     private func parseAudioOptions(from text: String) -> [AudioOption] {
         var audioOptions: [AudioOption] = []
         let audioSearch = /#EXT-X-MEDIA:TYPE=AUDIO,(?<attributes>.+)/
@@ -171,16 +170,14 @@ public actor PlaylistReader {
 
         let lines = text.components(separatedBy: .newlines)
         for line in lines {
-            // Only consider lines for audio options.
             guard let _ = try? audioSearch.firstMatch(in: line) else { continue }
             
-            // Extract language.
+            // Fixed capture group access
             guard let languageMatch = try? languageSearch.firstMatch(in: line) else { continue }
-            let language = String(languageMatch.language)
+            let language = String(languageMatch.output.language) // Add .output
             
-            // Extract URI.
             guard let uriMatch = try? uriSearch.firstMatch(in: line) else { continue }
-            let uriString = String(uriMatch.url)
+            let uriString = String(uriMatch.output.url) // Add .output
             
             let url: URL
             if let absoluteUrl = URL(string: uriString), absoluteUrl.host != nil {
@@ -192,7 +189,8 @@ public actor PlaylistReader {
             let option = AudioOption(url: url, language: language)
             audioOptions.append(option)
         }
-        
+        print("Found audio options")
+        print(audioOptions)
         return audioOptions
     }
 

--- a/Sources/Utils/PlaylistReader.swift
+++ b/Sources/Utils/PlaylistReader.swift
@@ -162,40 +162,34 @@ public actor PlaylistReader {
     /// Parses a list of Audio Options from
     /// - Parameter text: text to be parsed, expected to be the contents of an HLS m3u8 playlist file.
     /// - Returns: a list of Audio Options.
+
     private func parseAudioOptions(from text: String) -> [AudioOption] {
         var audioOptions: [AudioOption] = []
-        // Regex for lines that define an audio option.
         let audioSearch = /#EXT-X-MEDIA:TYPE=AUDIO,(?<attributes>.+)/
-        // Regex for extracting the LANGUAGE value.
         let languageSearch = /LANGUAGE="(?<language>[^"]+)"/
-        // Regex for extracting the URI.
         let uriSearch = /URI="(?<url>[^"]+)"/
 
         let lines = text.components(separatedBy: .newlines)
         for line in lines {
             // Only consider lines for audio options.
-            guard ((try? audioSearch.firstMatch(in: line) != nil) != nil) else { continue }
+            guard let _ = try? audioSearch.firstMatch(in: line) else { continue }
             
             // Extract language.
-            guard let languageMatch = try? languageSearch.firstMatch(in: line),
-                  let language = languageMatch.language else {
-                continue
-            }
+            guard let languageMatch = try? languageSearch.firstMatch(in: line) else { continue }
+            let language = String(languageMatch.language)
             
             // Extract URI.
-            guard let uriMatch = try? uriSearch.firstMatch(in: line),
-                  let uriString = uriMatch.url else {
-                continue
-            }
+            guard let uriMatch = try? uriSearch.firstMatch(in: line) else { continue }
+            let uriString = String(uriMatch.url)
+            
             let url: URL
             if let absoluteUrl = URL(string: uriString), absoluteUrl.host != nil {
                 url = absoluteUrl
             } else {
-                // For relative paths, use the same base URL as your current context.
                 url = URL(filePath: uriString, relativeTo: self.url)
             }
             
-            let option = AudioOption( url: url, language: language)
+            let option = AudioOption(url: url, language: language)
             audioOptions.append(option)
         }
         

--- a/Sources/Utils/PlaylistReader.swift
+++ b/Sources/Utils/PlaylistReader.swift
@@ -136,6 +136,7 @@ public actor PlaylistReader {
                let height = Int(resolution.height),
                let bitrate = Int(bandwidth.bitrate),
                index + 1 < lines.count {
+                let declarationLine = line // Capture the full declaration line
                 let url = {
                     // testing for host() ensures that the URL is absolute
                     if let playlistUrl = URL(string: lines[index + 1]),
@@ -150,7 +151,8 @@ public actor PlaylistReader {
                 let option = ResolutionOption(
                     size: CGSize(width: width, height: height),
                     bitrate: bitrate,
-                    url: url
+                    url: url,
+                    declarationLine: declarationLine
                 )
                 resolutions.append(option)
             }
@@ -186,7 +188,7 @@ public actor PlaylistReader {
                 url = URL(filePath: uriString, relativeTo: self.url)
             }
             
-            let option = AudioOption(url: url, language: language)
+            let option = AudioOption(url: url, language: language, declarationLine: line)
             audioOptions.append(option)
         }
         print("Found audio options")

--- a/Sources/Utils/PlaylistWriter.swift
+++ b/Sources/Utils/PlaylistWriter.swift
@@ -1,0 +1,40 @@
+//
+//  PlaylistWriter.swift
+//  OpenImmersive
+//
+//  Created by Zachary Handshoe on 2/24/25.
+//
+
+import Foundation
+
+class PlaylistWriter {
+    /// Writes an HLS playlist with the given video stream and audio option to a temporary file
+    /// - Parameters:
+    ///   - videoStreamInfo: The EXT-X-STREAM-INF line and URL for the video
+    ///   - audioMediaInfo: The EXT-X-MEDIA line for the audio option
+    /// - Returns: Text of a temporary file containing the playlist
+    /// - Throws: Error if writing fails
+    public func writeTemporaryPlaylist(videoStreamInfo: String, videoStreamUrl: String, audioMediaInfo: String) throws -> String {
+        // Build the playlist content
+        var playlistContent = "#EXTM3U\n"
+        playlistContent += "#EXT-X-VERSION:12\n"
+        
+        // Add the video information line
+        playlistContent += videoStreamInfo + "\n"
+        
+        // Add the video URL line
+        playlistContent += videoStreamUrl + "\n"
+        
+        // Add the audio media line
+//        playlistContent += audioMediaInfo + "\n"
+        
+        // Write the content to the temporary file
+        do {
+            print("Temporary Playlist Created")
+            return playlistContent
+        } catch {
+            print("Failed to write playlist: \(error.localizedDescription)")
+            throw error
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support for separate audio tracks in the replacement function. When a user today chooses to view at a specific resolution, if the HLS playlist has separate audio tracks, the audio is dropped from playback and the video resumes muted. 