### PR TITLE
Fixed an issue where a selected video from Files would not play a second time

### DIFF
--- a/Sources/Controllers/VideoPlayer.swift
+++ b/Sources/Controllers/VideoPlayer.swift
@@ -20,6 +20,8 @@ public class VideoPlayer: Sendable {
     private(set) public var title: String = ""
     /// A short description of the current video (empty string if none).
     private(set) public var details: String = ""
+    /// The url of the current video.
+    private(set) public var url: URL?
     /// The duration in seconds of the current video (0 if none).
     private(set) public var duration: Double = 0
     /// `true` if playback is currently paused, or if playback has completed.
@@ -102,25 +104,7 @@ public class VideoPlayer: Sendable {
     
     //MARK: Public methods
     /// Public initializer for visibility.
-    public init(title: String = "", details: String = "", duration: Double = 0, paused: Bool = false, buffering: Bool = false, hasReachedEnd: Bool = false, playbackEndedAction: CustomAction? = nil, aspectRatio: Float? = nil, horizontalFieldOfView: Float? = nil, bitrate: Double = 0, shouldShowControlPanel: Bool = true, currentTime: Double = 0, scrubState: VideoPlayer.ScrubState = .notScrubbing, timeObserver: Any? = nil, durationObserver: NSKeyValueObservation? = nil, bufferingObserver: NSKeyValueObservation? = nil, dismissControlPanelTask: Task<Void, Never>? = nil) {
-        self.title = title
-        self.details = details
-        self.duration = duration
-        self.paused = paused
-        self.buffering = buffering
-        self.hasReachedEnd = hasReachedEnd
-        self.playbackEndedAction = playbackEndedAction
-        if let aspectRatio { self.aspectRatio = aspectRatio }
-        if let horizontalFieldOfView { self.horizontalFieldOfView = horizontalFieldOfView }
-        self.bitrate = bitrate
-        self.shouldShowControlPanel = shouldShowControlPanel
-        self.currentTime = currentTime
-        self.scrubState = scrubState
-        self.timeObserver = timeObserver
-        self.durationObserver = durationObserver
-        self.bufferingObserver = bufferingObserver
-        self.dismissControlPanelTask = dismissControlPanelTask
-    }
+    public init() {}
     
     /// Instruct the UI to reveal the control panel.
     public func showControlPanel() {
@@ -166,6 +150,7 @@ public class VideoPlayer: Sendable {
         // Clean up the AVPlayer first, avoid bad states
         stop()
         
+        url = stream.url
         title = stream.title
         details = stream.details
         

--- a/Sources/Models/StreamModel.swift
+++ b/Sources/Models/StreamModel.swift
@@ -29,8 +29,6 @@ public struct StreamModel: Codable {
     public var url: URL
     /// The projection type of the media.
     public var projection: Projection
-    /// True if the media required user permission for access.
-    public var isSecurityScoped: Bool
     
     /// Public initializer for visibility.
     /// - Parameters:
@@ -38,13 +36,11 @@ public struct StreamModel: Codable {
     ///   - details: a short description of the video stream.
     ///   - url: URL to a media, whether local or streamed from a server (m3u8).
     ///   - projection: the projection type of the media (default 180.0 degree equirectangular).
-    ///   - isSecurityScoped: true if the media required user permission for access (default false).
-    public init(title: String, details: String, url: URL, projection: Projection = .equirectangular(fieldOfView: 180.0), isSecurityScoped: Bool = false) {
+    public init(title: String, details: String, url: URL, projection: Projection = .equirectangular(fieldOfView: 180.0)) {
         self.title = title
         self.details = details
         self.url = url
         self.projection = projection
-        self.isSecurityScoped = isSecurityScoped
     }
 }
 

--- a/Sources/Views/FilePicker.swift
+++ b/Sources/Views/FilePicker.swift
@@ -33,11 +33,14 @@ public struct FilePicker: View {
         ) { result in
             switch result {
             case .success(let url):
+                // Hack: this should be mirrored by url.stopAccessingSecurityScopedResource(),
+                // but it would prevent playing the same file twice.
+                url.startAccessingSecurityScopedResource()
+                
                 let stream = StreamModel(
                     title: url.lastPathComponent,
                     details: "From Local Files",
-                    url: url,
-                    isSecurityScoped: url.startAccessingSecurityScopedResource()
+                    url: url
                 )
                 loadStreamAction(stream)
                 break

--- a/Sources/Views/ImmersivePlayer.swift
+++ b/Sources/Views/ImmersivePlayer.swift
@@ -133,9 +133,6 @@ public struct ImmersivePlayer: View {
             videoPlayer.stop()
             videoPlayer.hideControlPanel()
             headTracker.stop()
-            if selectedStream.isSecurityScoped {
-                selectedStream.url.stopAccessingSecurityScopedResource()
-            }
         }
         .gesture(TapGesture()
             .targetedToAnyEntity()

--- a/Sources/Views/SpatialVideoPicker.swift
+++ b/Sources/Views/SpatialVideoPicker.swift
@@ -41,8 +41,7 @@ public struct SpatialVideoPicker: View {
                         let stream = StreamModel(
                             title: video.url.lastPathComponent,
                             details: "From Local Gallery",
-                            url: video.url,
-                            isSecurityScoped: false
+                            url: video.url
                         )
                         loadStreamAction(stream)
                     }

--- a/Sources/Views/StreamUrlInput.swift
+++ b/Sources/Views/StreamUrlInput.swift
@@ -115,8 +115,7 @@ public struct StreamUrlInput: View {
         let stream = StreamModel(
             title: "HLS Stream",
             details: url.absoluteString,
-            url: url,
-            isSecurityScoped: false
+            url: url
         )
         
         loadStreamAction(stream)


### PR DESCRIPTION
This is due to URL.startAccessingSecurityScopedResource() being mirrored with URL.stopAccessingSecurityScopedResource(), and in our case once we stop accessing security scoped resources at runtime we cannot access them again. API doc warns of leak of kernel resources, but in our case it's a lesser evil than having users confused as to why they cannot play a same video twice.