### PR TITLE
Fixed equirectangular videos not rendering in visionOS 26

### DIFF
--- a/Sources/Controllers/VideoPlayer.swift
+++ b/Sources/Controllers/VideoPlayer.swift
@@ -37,7 +37,7 @@ public class VideoPlayer: Sendable {
     /// The callback to execute when playback reaches the end of the video.
     public var playbackEndedAction: CustomAction?
     /// The aspect ratio of the current media (width / height) (equirectangular projection only).
-    private(set) public var aspectRatio: Float = 1.0
+    private(set) public var aspectRatio: Float?
     /// The horizontal field of view for the current media (equirectangular projection only).
     private(set) public var horizontalFieldOfView: Float = 180.0
     /// The vertical field of view for the current media (equirectangular projection only).
@@ -45,6 +45,7 @@ public class VideoPlayer: Sendable {
         get {
             // some 180/360 videos are originally encoded with non-square pixels, so don't use the aspect ratio for those.
             if self.horizontalFieldOfView >= 180.0 { return 180.0 }
+            let aspectRatio = self.aspectRatio ?? 1.0
             return max(0, min(180, self.horizontalFieldOfView / aspectRatio))
         }
     }

--- a/Sources/Models/VideoScreen.swift
+++ b/Sources/Models/VideoScreen.swift
@@ -26,6 +26,7 @@ public class VideoScreen {
     /// Updates the video screen mesh with values from a VideoPlayer instance to resize it and start displaying its video media.
     /// - Parameters:
     ///   - videoPlayer: the VideoPlayer instance
+    ///   - projection: the projection type of the media
     public func update(source videoPlayer: VideoPlayer, projection: StreamModel.Projection) {
         switch projection {
         case .equirectangular(fieldOfView: _, force: _):
@@ -67,7 +68,8 @@ public class VideoScreen {
     /// Sets up the entity with a VideoPlayerComponent that renders the video natively.
     /// - Parameters:
     ///   - videoPlayer:the VideoPlayer instance
-    private func updateNativePlayer(_ videoPlayer: VideoPlayer, transform: Transform = Transform()) {
+    ///   - transform: the position of the entity (default identity)
+    private func updateNativePlayer(_ videoPlayer: VideoPlayer, transform: Transform = .identity) {
         let videoPlayerComponent = {
             var videoPlayerComponent = VideoPlayerComponent(avPlayer: videoPlayer.player)
             videoPlayerComponent.desiredViewingMode = .stereo


### PR DESCRIPTION
An interesting change in SwiftUI/Observation between visionOS 2 and visionOS 26 is that setting an observed value when newValue == oldValue doesn't fire `withObservationTracking {} onChange:` which is probably the correct behavior. 
But that would break the generation of the sphere geometry, which awaits the aspect ratio of the video, from either the inspection of the field of view for local MV-HEVC files or the reading of the playlist for HLS streams. Since it was set to 1.0, and all 180 half-equirectangular videos are also with a square aspect ration, it had to be initialized at nil to make sure it'd get set and fire the observation tracking callback.