### PR TITLE
Made the projection in StreamModel optional, auto-select AIVU from FilePicker

### DIFF
--- a/Sources/Models/StreamModel.swift
+++ b/Sources/Models/StreamModel.swift
@@ -27,16 +27,16 @@ public struct StreamModel: Codable {
     public var details: String
     /// URL to a media, whether local or streamed from a HLS server (m3u8).
     public var url: URL
-    /// The projection type of the media.
-    public var projection: Projection
+    /// The projection type of the media (will default to 180.0 degree equirectangular if nil).
+    public var projection: Projection?
     
     /// Public initializer for visibility.
     /// - Parameters:
     ///   - title: the title of the video stream.
     ///   - details: a short description of the video stream.
     ///   - url: URL to a media, whether local or streamed from a server (m3u8).
-    ///   - projection: the projection type of the media (default 180.0 degree equirectangular).
-    public init(title: String, details: String, url: URL, projection: Projection = .equirectangular(fieldOfView: 180.0)) {
+    ///   - projection: the projection type of the media (default nil).
+    public init(title: String, details: String, url: URL, projection: Projection? = nil) {
         self.title = title
         self.details = details
         self.url = url

--- a/Sources/Views/FilePicker.swift
+++ b/Sources/Views/FilePicker.swift
@@ -37,10 +37,12 @@ public struct FilePicker: View {
                 // but it would prevent playing the same file twice.
                 url.startAccessingSecurityScopedResource()
                 
+                let isAivuFile = url.lastPathComponent.hasSuffix(".aivu")
                 let stream = StreamModel(
                     title: url.lastPathComponent,
                     details: "From Local Files",
-                    url: url
+                    url: url,
+                    projection: isAivuFile ? .appleImmersive : nil
                 )
                 loadStreamAction(stream)
                 break

--- a/Sources/Views/ImmersivePlayer.swift
+++ b/Sources/Views/ImmersivePlayer.swift
@@ -153,7 +153,8 @@ public struct ImmersivePlayer: View {
             videoPlayer.showControlPanel()
             videoPlayer.play()
             
-            videoScreen.update(source: videoPlayer, projection: selectedStream.projection)
+            let projection = selectedStream.projection ?? .equirectangular(fieldOfView: 180)
+            videoScreen.update(source: videoPlayer, projection: projection)
         }
         .onDisappear {
             videoPlayer.stop()


### PR DESCRIPTION
let the ImmersivePlaye default projection to Equirectangular(180), FilePicker now specifies the projection as AppleImmersive when it knows the file is aivu.