### PR TITLE
Add subtitle parsing/overlay support for immersive playback

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/OpenImmersive.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/OpenImmersive.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2610"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "OpenImmersiveLib"
+               BuildableName = "OpenImmersiveLib"
+               BlueprintName = "OpenImmersiveLib"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "OpenImmersiveLib"
+            BuildableName = "OpenImmersiveLib"
+            BlueprintName = "OpenImmersiveLib"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,42 @@
+{
+  "originHash" : "f88097d977cd2aa8e57140ccd96d87b15440a0c7a87d1b05a55998f661ea2efb",
+  "pins" : [
+    {
+      "identity" : "bytesparser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/dagronf/BytesParser",
+      "state" : {
+        "revision" : "a091513c4059d336c8cbf0b9485fcba63bcba83a",
+        "version" : "3.2.1"
+      }
+    },
+    {
+      "identity" : "dsfregex",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/dagronf/DSFRegex",
+      "state" : {
+        "revision" : "c576aab25f88bcb4b549862e6269b6f90b917e0c",
+        "version" : "4.0.0"
+      }
+    },
+    {
+      "identity" : "swiftsubtitles",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/dagronf/SwiftSubtitles",
+      "state" : {
+        "revision" : "485c6f1fc71235041198a8bb893fa22f807451a6",
+        "version" : "2.2.0"
+      }
+    },
+    {
+      "identity" : "tinycsv",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/dagronf/TinyCSV",
+      "state" : {
+        "revision" : "05d691ee7bab64f5ff075b97f47ef41d36a81f6f",
+        "version" : "1.0.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Package.swift
+++ b/Package.swift
@@ -12,11 +12,23 @@ let package = Package(
             name: "OpenImmersiveLib",
             targets: ["OpenImmersive"]),
     ],
+    dependencies: [
+        .package(url: "https://github.com/dagronf/SwiftSubtitles", from: "2.0.0")
+    ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
         // Targets can depend on other targets in this package and products from dependencies.
         .target(
-            name: "OpenImmersive"),
+            name: "OpenImmersive",
+            dependencies: [
+                .product(name: "SwiftSubtitles", package: "SwiftSubtitles")
+            ]
+        ),
+        .testTarget(
+            name: "OpenImmersiveTests",
+            dependencies: ["OpenImmersive"],
+            resources: [.process("TestAssets")]
+        ),
 
     ]
 )

--- a/Sources/Controllers/SubtitleController.swift
+++ b/Sources/Controllers/SubtitleController.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+/// Manages subtitle cues and provides efficient time-based lookups during playback
+@Observable
+public class SubtitleController {
+    private var cues: [SubtitleCue]
+    private var currentIndex: Int = 0
+
+    public init(cues: [SubtitleCue]) {
+        // Sort cues by start time to ensure they're in chronological order
+        self.cues = cues.sorted { $0.startTime < $1.startTime }
+    }
+
+    /// Get the subtitle cue that should be displayed at the given time
+    /// Returns nil if no cue is active at the specified time
+    public func cue(at time: TimeInterval) -> SubtitleCue? {
+        // Fast path: Check if current index is still valid
+        if currentIndex < cues.count {
+            let current = cues[currentIndex]
+            if current.isActive(at: time) {
+                return current
+            }
+        }
+
+        // Search forward from current position
+        if currentIndex < cues.count {
+            for i in currentIndex..<cues.count {
+                let cue = cues[i]
+                if cue.isActive(at: time) {
+                    currentIndex = i
+                    return cue
+                }
+                // If we've passed the time, no need to continue
+                if cue.startTime > time {
+                    break
+                }
+            }
+        }
+
+        // Search backward (in case of seek backward)
+        if currentIndex > 0 {
+            for i in (0..<currentIndex).reversed() {
+                let cue = cues[i]
+                if cue.isActive(at: time) {
+                    currentIndex = i
+                    return cue
+                }
+                // If we've gone too far back, stop
+                if cue.endTime < time {
+                    break
+                }
+            }
+        }
+
+        // No active cue at this time
+        return nil
+    }
+
+    /// Reset the controller (useful when seeking to start or loading new subtitles)
+    public func reset() {
+        currentIndex = 0
+    }
+
+    /// Get all cues (for debugging or UI purposes)
+    public func allCues() -> [SubtitleCue] {
+        return cues
+    }
+
+    /// Total number of cues
+    public var cueCount: Int {
+        return cues.count
+    }
+
+    /// Duration of the entire subtitle track (from first cue start to last cue end)
+    public var totalDuration: TimeInterval? {
+        guard let first = cues.first, let last = cues.last else {
+            return nil
+        }
+        return last.endTime - first.startTime
+    }
+}

--- a/Sources/Controllers/SubtitleParser.swift
+++ b/Sources/Controllers/SubtitleParser.swift
@@ -1,0 +1,150 @@
+import Foundation
+import SwiftSubtitles
+
+/// Wrapper around SwiftSubtitles library for parsing subtitle files
+public class SubtitleParser {
+
+    public enum SubtitleFormat: String {
+        case srt = "srt"
+        case webvtt = "vtt"
+        case sbv = "sbv"
+        case ssa = "ssa"
+        case ass = "ass"
+
+        public static func from(fileExtension: String) -> SubtitleFormat? {
+            switch fileExtension.lowercased() {
+            case "srt": return .srt
+            case "vtt", "webvtt": return .webvtt
+            case "sbv": return .sbv
+            case "ssa": return .ssa
+            case "ass": return .ass
+            default: return nil
+            }
+        }
+    }
+
+    public enum ParserError: Error, LocalizedError {
+        case unsupportedFormat(String)
+        case fileReadError(Error)
+        case parsingError(Error)
+        case invalidURL
+        case networkError(Error)
+
+        public var errorDescription: String? {
+            switch self {
+            case .unsupportedFormat(let ext):
+                return "Unsupported subtitle format: .\(ext)"
+            case .fileReadError(let error):
+                return "Failed to read subtitle file: \(error.localizedDescription)"
+            case .parsingError(let error):
+                return "Failed to parse subtitle file: \(error.localizedDescription)"
+            case .invalidURL:
+                return "Invalid subtitle file URL"
+            case .networkError(let error):
+                return "Failed to download subtitle file: \(error.localizedDescription)"
+            }
+        }
+    }
+
+    public init() {}
+
+    /// Parse a subtitle file and return an array of SubtitleCue objects
+    public func parse(fileURL: URL) throws -> [SubtitleCue] {
+        // Validate file extension
+        let fileExtension = fileURL.pathExtension
+        guard SubtitleFormat.from(fileExtension: fileExtension) != nil else {
+            throw ParserError.unsupportedFormat(fileExtension)
+        }
+
+        // Parse using SwiftSubtitles (automatically detects format)
+        let subtitles: Subtitles
+        do {
+            subtitles = try Subtitles(fileURL: fileURL, encoding: .utf8)
+        } catch {
+            throw ParserError.parsingError(error)
+        }
+
+        // Convert to our SubtitleCue model
+        return subtitles.cues.map { cue in
+            SubtitleCue(
+                startTime: cue.startTime.timeInSeconds,
+                endTime: cue.endTime.timeInSeconds,
+                text: cue.text
+            )
+        }
+    }
+
+    /// Parse subtitle data from a string
+    public func parse(string: String, format: SubtitleFormat = .srt) throws -> [SubtitleCue] {
+        let subtitles: Subtitles
+        do {
+            let coder = coder(for: format)
+            guard let data = string.data(using: .utf8) else {
+                throw ParserError.parsingError(NSError(domain: "SubtitleParser", code: -1, userInfo: [NSLocalizedDescriptionKey: "Could not encode string as UTF-8"]))
+            }
+            subtitles = try coder.decode(data, encoding: .utf8)
+        } catch {
+            throw ParserError.parsingError(error)
+        }
+
+        return subtitles.cues.map { cue in
+            SubtitleCue(
+                startTime: cue.startTime.timeInSeconds,
+                endTime: cue.endTime.timeInSeconds,
+                text: cue.text
+            )
+        }
+    }
+
+    /// Parse subtitles from a URL (supports both local files and remote URLs)
+    /// - Parameters:
+    ///   - url: URL to the subtitle file (local file URL or remote http/https URL)
+    /// - Returns: Array of SubtitleCue objects
+    public func parse(url: URL) async throws -> [SubtitleCue] {
+        let fileExtension = url.pathExtension
+        guard let format = SubtitleFormat.from(fileExtension: fileExtension) else {
+            throw ParserError.unsupportedFormat(fileExtension)
+        }
+
+        // Check if this is a remote URL
+        if url.scheme == "http" || url.scheme == "https" {
+            return try await parseRemote(url: url, format: format)
+        } else {
+            // Local file - use existing synchronous parsing
+            return try parse(fileURL: url)
+        }
+    }
+
+    /// Parse subtitles from a remote URL
+    private func parseRemote(url: URL, format: SubtitleFormat) async throws -> [SubtitleCue] {
+        let data: Data
+        do {
+            let (downloadedData, _) = try await URLSession.shared.data(from: url)
+            data = downloadedData
+        } catch {
+            throw ParserError.networkError(error)
+        }
+
+        guard let content = String(data: data, encoding: .utf8) else {
+            throw ParserError.parsingError(NSError(domain: "SubtitleParser", code: -1, userInfo: [NSLocalizedDescriptionKey: "Could not decode subtitle data as UTF-8"]))
+        }
+
+        return try parse(string: content, format: format)
+    }
+
+    /// Get the appropriate coder for a subtitle format
+    private func coder(for format: SubtitleFormat) -> SubtitlesCodable {
+        switch format {
+        case .srt:
+            return Subtitles.Coder.SRT.Create()
+        case .webvtt:
+            return Subtitles.Coder.VTT.Create()
+        case .sbv:
+            return Subtitles.Coder.SBV.Create()
+        case .ssa:
+            return Subtitles.Coder.SubStationAlpha.Create()
+        case .ass:
+            return Subtitles.Coder.AdvancedSSA.Create()
+        }
+    }
+}

--- a/Sources/Controllers/VideoPlayer.swift
+++ b/Sources/Controllers/VideoPlayer.swift
@@ -83,6 +83,8 @@ public class VideoPlayer: Sendable {
     }
 
     /// Subtitle support
+    /// Subtitle URL configured for the current item (if any).
+    private(set) public var configuredSubtitleURL: URL? = nil
     private(set) public var currentSubtitle: String? = nil
     private(set) public var subtitleVersion: UInt64 = 0
     private(set) public var subtitleController: SubtitleController? = nil
@@ -98,6 +100,11 @@ public class VideoPlayer: Sendable {
     }
     public var subtitlesAreAvailable: Bool {
         subtitleController != nil
+    }
+    
+    /// `true` if subtitles are configured for the current item (even if not yet loaded).
+    public var subtitlesOptionAvailable: Bool {
+        configuredSubtitleURL != nil || subtitlesAreAvailable
     }
 
     /// The current time in seconds of the current video (0 if none).
@@ -187,7 +194,7 @@ public class VideoPlayer: Sendable {
     ///
     /// This will only do something if resolution or audio options are available.
     public func togglePlaybackOptions() {
-        if bitrateLadder.count > 1 || audioOptions.count > 1 {
+        if canChooseResolution || canChooseAudio || subtitlesOptionAvailable {
             withAnimation {
                 shouldShowPlaybackOptions.toggle()
             }
@@ -218,6 +225,7 @@ public class VideoPlayer: Sendable {
         stop()
         
         url = item.url
+        configuredSubtitleURL = item.subtitleURL
         title = item.metadata[.commonIdentifierTitle] ?? ""
         description = item.metadata[.commonIdentifierDescription] ?? ""
         metadata = item.metadata
@@ -432,6 +440,7 @@ public class VideoPlayer: Sendable {
         player.replaceCurrentItem(with: nil)
         title = ""
         description = ""
+        configuredSubtitleURL = nil
         duration = 0
         currentTime = 0
         bitrate = 0

--- a/Sources/Controllers/VideoPlayer.swift
+++ b/Sources/Controllers/VideoPlayer.swift
@@ -492,6 +492,33 @@ public class VideoPlayer: Sendable {
         player.subtitlesVisibilityEnabled = true
         return player
     }
+
+    /// Convenience factory for SwiftUI previews with playback settings available.
+    public static func previewWithSubtitlesAndPlaybackOptions() -> VideoPlayer {
+        let player = previewWithSubtitles()
+        player.bitrateLadder = [
+            BitrateRung(
+                size: CGSize(width: 1280, height: 720),
+                averageBitrate: 2_000_000,
+                peakBitrate: 2_500_000,
+                url: URL(string: "https://example.com/720p.m3u8")!
+            ),
+            BitrateRung(
+                size: CGSize(width: 1920, height: 1080),
+                averageBitrate: 4_500_000,
+                peakBitrate: 5_500_000,
+                url: URL(string: "https://example.com/1080p.m3u8")!
+            )
+        ]
+        player.selectedBitrateRungIndex = 1
+        player.audioOptions = [
+            AudioOption(url: URL(string: "https://example.com/en.m3u8")!, groupId: "eng", name: "English", language: "en"),
+            AudioOption(url: URL(string: "https://example.com/es.m3u8")!, groupId: "spa", name: "Spanish", language: "es")
+        ]
+        player.selectedAudioIndex = 0
+        player.bitrate = 4_500_000
+        return player
+    }
     #endif
 
     //MARK: Private methods

--- a/Sources/Models/SubtitleCue.swift
+++ b/Sources/Models/SubtitleCue.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Represents a single subtitle entry with timing and text content
+public struct SubtitleCue: Identifiable, Equatable {
+    public let id: UUID
+    public let startTime: TimeInterval
+    public let endTime: TimeInterval
+    public let text: String
+
+    public init(
+        id: UUID = UUID(),
+        startTime: TimeInterval,
+        endTime: TimeInterval,
+        text: String
+    ) {
+        self.id = id
+        self.startTime = startTime
+        self.endTime = endTime
+        self.text = text
+    }
+
+    /// Check if this cue should be displayed at the given time
+    public func isActive(at time: TimeInterval) -> Bool {
+        return time >= startTime && time < endTime
+    }
+
+    /// Duration of this subtitle cue in seconds
+    public var duration: TimeInterval {
+        return endTime - startTime
+    }
+}

--- a/Sources/Models/VideoItem.swift
+++ b/Sources/Models/VideoItem.swift
@@ -8,6 +8,7 @@
 import AVFoundation
 
 /// Simple structure describing a video.
+/// Note: HLS manifest subtitle tracks are not parsed; provide subtitles as a sidecar file URL (local or remote).
 public struct VideoItem: Codable {
     public enum Projection: Codable {
         /// Spherical projection of an equirectangular (or half equirectangular) frame. Use this for mono or MV-HEVC stereo VR180 & VR360 video.
@@ -20,23 +21,27 @@ public struct VideoItem: Codable {
         /// Native rendering for Apple Immersive Video (AIVU).
         case appleImmersive
     }
-    
+
     /// Dictionary of metadata values for the video. `commonIdentifierTitle` and `commonIdentifierDescription` are expected.
     public var metadata: [AVMetadataIdentifier: String]
     /// URL to a media, whether local or streamed from a HLS server (m3u8).
     public var url: URL
     /// The projection type of the media (will default to 180.0 degree equirectangular if nil).
     public var projection: Projection?
-    
+    /// URL to a subtitle file (SRT, VTT, etc.), either local or remote.
+    public var subtitleURL: URL?
+
     /// Public initializer for visibility.
     /// - Parameters:
     ///   - metadata: dictionary of metadata values for the video. `commonIdentifierTitle` and `commonIdentifierDescription` are expected.
     ///   - url: URL to a media, whether local or streamed from a HLS server (m3u8).
     ///   - projection: the projection type of the media (default nil).
-    public init(metadata: [AVMetadataIdentifier: String], url: URL, projection: Projection? = nil) {
+    ///   - subtitleURL: URL to a subtitle file (default nil).
+    public init(metadata: [AVMetadataIdentifier: String], url: URL, projection: Projection? = nil, subtitleURL: URL? = nil) {
         self.metadata = metadata
         self.url = url
         self.projection = projection
+        self.subtitleURL = subtitleURL
     }
 }
 

--- a/Sources/Views/ControlPanel.swift
+++ b/Sources/Views/ControlPanel.swift
@@ -72,7 +72,10 @@ public struct ControlPanel: View {
                     
                     HStack {
                         PlaybackButtons(videoPlayer: videoPlayer)
-                        
+                        if videoPlayer.subtitlesAreAvailable {
+                            SubtitleToggle(videoPlayer: $videoPlayer)
+                        }
+
                         Scrubber(videoPlayer: $videoPlayer)
                         
                         TimeText(videoPlayer: videoPlayer)
@@ -160,6 +163,31 @@ public struct ResolutionToggle: View {
             }
         }
         .frame(width: 50)
+    }
+}
+
+/// A toggle to show or hide subtitles when available.
+public struct SubtitleToggle: View {
+    /// The singleton video player control interface.
+    @Binding var videoPlayer: VideoPlayer
+
+    /// Public initializer for visibility.
+    /// - Parameters:
+    ///   - videoPlayer: the binding to the singleton video player control interface.
+    public init(videoPlayer: Binding<VideoPlayer>) {
+        self._videoPlayer = videoPlayer
+    }
+
+    public var body: some View {
+        let isOn = Binding<Bool>(
+            get: { videoPlayer.subtitlesVisibilityEnabled },
+            set: { videoPlayer.subtitlesVisibilityEnabled = $0 }
+        )
+
+        Toggle("", systemImage: videoPlayer.subtitlesVisibilityEnabled ? "captions.bubble.fill" : "captions.bubble", isOn: isOn)
+            .toggleStyle(.button)
+            .accessibilityLabel("Subtitles")
+            .frame(width: 80)
     }
 }
 
@@ -489,6 +517,14 @@ public struct VariantSelector: View {
 //    ControlPanel(videoPlayer: .constant(VideoPlayer()))
 //}
 
+private struct ControlPanelPreviewContainer: View {
+    @State private var videoPlayer = VideoPlayer.previewWithSubtitles()
+    
+    var body: some View {
+        ControlPanel(videoPlayer: $videoPlayer)
+    }
+}
+
 #Preview {
     RealityView { content, attachments in
         if let entity = attachments.entity(for: "ControlPanel") {
@@ -496,7 +532,7 @@ public struct VariantSelector: View {
         }
     } attachments: {
         Attachment(id: "ControlPanel") {
-            ControlPanel(videoPlayer: .constant(VideoPlayer()))
+            ControlPanelPreviewContainer()
         }
     }
 }

--- a/Sources/Views/ControlPanel.swift
+++ b/Sources/Views/ControlPanel.swift
@@ -105,7 +105,7 @@ public struct MediaInfo: View {
             .truncationMode(.tail)
             
             HStack(spacing: 12) {
-                if videoPlayer.canChooseResolution || videoPlayer.canChooseAudio {
+                if videoPlayer.canChooseResolution || videoPlayer.canChooseAudio || videoPlayer.subtitlesOptionAvailable {
                     ResolutionToggle(videoPlayer: $videoPlayer)
                 }
             }
@@ -357,7 +357,7 @@ public struct VariantSelector: View {
     
     public var body: some View {
         VStack(alignment: .trailing) {
-            if videoPlayer.canChooseAudio {
+            if videoPlayer.canChooseAudio || videoPlayer.subtitlesOptionAvailable {
                 let options = videoPlayer.audioOptions
                 let zippedOptions = Array(zip(options.indices, options))
                 let isOn: (Int) -> Binding<Bool> = { index in
@@ -369,28 +369,30 @@ public struct VariantSelector: View {
                 }
                 
                 HStack {
-                    if videoPlayer.subtitlesAreAvailable {
+                    if videoPlayer.subtitlesOptionAvailable {
                         SubtitleToggle(videoPlayer: $videoPlayer)
                     }
-                    Toggle(isOn: isOn(-1)) {
-                        Text("Default")
-                            .font(.headline)
-                    }
-                    .toggleStyle(.button)
-                    
-                    ForEach(zippedOptions, id: \.0) { index, option in
-                        Toggle(isOn: isOn(index)) {
-                            VStack(spacing: -3) {
-                                Text(option.description)
-                                    .font(.caption)
-                                
-                                Text(option.groupId.capitalized)
-                                    .font(.caption2)
-                                    .opacity(0.8)
-                            }
-                            .padding(.vertical, -5)
+                    if videoPlayer.canChooseAudio {
+                        Toggle(isOn: isOn(-1)) {
+                            Text("Default")
+                                .font(.headline)
                         }
                         .toggleStyle(.button)
+                        
+                        ForEach(zippedOptions, id: \.0) { index, option in
+                            Toggle(isOn: isOn(index)) {
+                                VStack(spacing: -3) {
+                                    Text(option.description)
+                                        .font(.caption)
+                                    
+                                    Text(option.groupId.capitalized)
+                                        .font(.caption2)
+                                        .opacity(0.8)
+                                }
+                                .padding(.vertical, -5)
+                            }
+                            .toggleStyle(.button)
+                        }
                     }
                 }
             }

--- a/Sources/Views/SubtitleOverlay.swift
+++ b/Sources/Views/SubtitleOverlay.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+/// Displays subtitle text overlaid on the immersive video player
+public struct SubtitleOverlay: View {
+    let videoPlayer: VideoPlayer
+
+    public init(videoPlayer: VideoPlayer) {
+        self.videoPlayer = videoPlayer
+    }
+
+    public var body: some View {
+        if let subtitle = videoPlayer.currentSubtitle, !subtitle.isEmpty {
+            Text(subtitle)
+                .font(.title)
+                .fontWeight(.medium)
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.white)
+                .padding(.horizontal, 24)
+                .padding(.vertical, 16)
+                .background {
+                    RoundedRectangle(cornerRadius: 12)
+                        .fill(.black.opacity(0.75))
+                }
+                .shadow(color: .black.opacity(0.3), radius: 4, x: 0, y: 2)
+                .frame(maxWidth: 600)
+        }
+    }
+}

--- a/Tests/OpenImmersiveTests/SubtitleParserTests.swift
+++ b/Tests/OpenImmersiveTests/SubtitleParserTests.swift
@@ -1,0 +1,142 @@
+import XCTest
+@testable import OpenImmersive
+
+final class SubtitleParserTests: XCTestCase {
+
+    var parser: SubtitleParser!
+
+    override func setUp() {
+        super.setUp()
+        parser = SubtitleParser()
+    }
+
+    // MARK: - Format Detection
+
+    func testFormatDetectionSRT() {
+        let format = SubtitleParser.SubtitleFormat.from(fileExtension: "srt")
+        XCTAssertEqual(format, .srt)
+    }
+
+    func testFormatDetectionVTT() {
+        let format = SubtitleParser.SubtitleFormat.from(fileExtension: "vtt")
+        XCTAssertEqual(format, .webvtt)
+    }
+
+    func testFormatDetectionASS() {
+        let format = SubtitleParser.SubtitleFormat.from(fileExtension: "ass")
+        XCTAssertEqual(format, .ass)
+    }
+
+    func testFormatDetectionUnknown() {
+        let format = SubtitleParser.SubtitleFormat.from(fileExtension: "unknown")
+        XCTAssertNil(format)
+    }
+
+    // MARK: - SRT Parsing
+
+    func testParseSRTFile() throws {
+        let url = try getTestAssetURL(filename: "sample_subtitles", extension: "srt")
+        let cues = try parser.parse(fileURL: url)
+
+        XCTAssertEqual(cues.count, 7, "Should parse all 7 cues")
+
+        // First cue
+        XCTAssertEqual(cues[0].text, "Welcome to the immersive video experience")
+        XCTAssertEqual(cues[0].startTime, 0.0, accuracy: 0.001)
+        XCTAssertEqual(cues[0].endTime, 3.0, accuracy: 0.001)
+
+        // Last cue
+        XCTAssertEqual(cues[6].text, "Enjoy your immersive video!")
+        XCTAssertEqual(cues[6].startTime, 23.5, accuracy: 0.001)
+    }
+
+    // MARK: - WebVTT Parsing
+
+    func testParseWebVTTFile() throws {
+        let url = try getTestAssetURL(filename: "sample_subtitles", extension: "vtt")
+        let cues = try parser.parse(fileURL: url)
+
+        XCTAssertEqual(cues.count, 7, "Should parse all 7 cues")
+
+        // First cue
+        XCTAssertEqual(cues[0].text, "Welcome to the immersive video experience")
+        XCTAssertEqual(cues[0].startTime, 0.0, accuracy: 0.001)
+        XCTAssertEqual(cues[0].endTime, 3.0, accuracy: 0.001)
+    }
+
+    // MARK: - ASS Parsing
+
+    func testParseASSFile() throws {
+        let url = try getTestAssetURL(filename: "sample_subtitles", extension: "ass")
+        let cues = try parser.parse(fileURL: url)
+
+        XCTAssertEqual(cues.count, 7, "Should parse all 7 cues")
+        XCTAssertEqual(cues[0].text, "Welcome to the immersive video experience")
+    }
+
+    // MARK: - JSON Parsing (String-based)
+
+    func testParseJSONFile() throws {
+        let url = try getTestAssetURL(filename: "sample_subtitles", extension: "json")
+        let data = try Data(contentsOf: url)
+
+        // JSON format is not directly supported by SwiftSubtitles,
+        // but we can verify the file exists and is valid JSON
+        let json = try JSONSerialization.jsonObject(with: data)
+        XCTAssertNotNil(json, "JSON file should be valid")
+    }
+
+    // MARK: - TTML Parsing
+
+    func testParseTTMLFile() throws {
+        let url = try getTestAssetURL(filename: "sample_subtitles", extension: "ttml")
+
+        // TTML is XML-based, verify it's well-formed and accessible
+        let data = try Data(contentsOf: url)
+        let xml = try XMLParser(data: data)
+        XCTAssertTrue(xml.parse(), "TTML file should be valid XML")
+    }
+
+    // MARK: - LRC Parsing
+
+    func testParseLRCFile() throws {
+        let url = try getTestAssetURL(filename: "sample_subtitles", extension: "lrc")
+
+        // LRC files exist, verify they're readable
+        let content = try String(contentsOf: url, encoding: .utf8)
+        XCTAssertTrue(content.contains("["), "LRC file should contain timestamp markers")
+    }
+
+    // MARK: - Unsupported Format
+
+    func testParseUnsupportedFormat() throws {
+        let tempURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("test.xyz")
+
+        do {
+            _ = try parser.parse(fileURL: tempURL)
+            XCTFail("Should throw unsupportedFormat error")
+        } catch let error as SubtitleParser.ParserError {
+            if case .unsupportedFormat(let ext) = error {
+                XCTAssertEqual(ext, "xyz")
+            } else {
+                XCTFail("Should be unsupportedFormat error")
+            }
+        }
+    }
+
+    // MARK: - Helper Methods
+
+    private func getTestAssetURL(filename: String, extension: String) throws -> URL {
+        #if os(visionOS)
+        let bundle = Bundle.main
+        #else
+        let bundle = Bundle.module
+        #endif
+
+        guard let url = bundle.url(forResource: filename, withExtension: `extension`, subdirectory: "TestAssets") else {
+            throw NSError(domain: "TestError", code: -1, userInfo: [NSLocalizedDescriptionKey: "Could not find test asset: \(filename).\(`extension`)"])
+        }
+
+        return url
+    }
+}

--- a/Tests/OpenImmersiveTests/TestAssets/sample_subtitles.ass
+++ b/Tests/OpenImmersiveTests/TestAssets/sample_subtitles.ass
@@ -1,0 +1,21 @@
+[Script Info]
+Title: Sample ASS Subtitles
+ScriptType: v4.00+
+Collisions: Normal
+PlayResX: 640
+PlayResY: 480
+Timer: 100.0000
+
+[V4+ Styles]
+Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
+Style: Default,Arial,20,&H00FFFFFF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,1,0,2,0,0,0,1
+
+[Events]
+Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
+Dialogue: 0,0:00:00.00,0:00:03.00,Default,,0,0,0,,Welcome to the immersive video experience
+Dialogue: 0,0:00:03.50,0:00:07.00,Default,,0,0,0,,This is a sample ASS subtitle file
+Dialogue: 0,0:00:07.50,0:00:11.00,Default,,0,0,0,,Testing the caption display system
+Dialogue: 0,0:00:11.50,0:00:15.00,Default,,0,0,0,,Subtitles appear at the bottom of your view
+Dialogue: 0,0:00:15.50,0:00:19.00,Default,,0,0,0,,Tap the CC button to load subtitle files
+Dialogue: 0,0:00:19.50,0:00:23.00,Default,,0,0,0,,Supports multiple subtitle formats
+Dialogue: 0,0:00:23.50,0:00:27.00,Default,,0,0,0,,Enjoy your immersive video!

--- a/Tests/OpenImmersiveTests/TestAssets/sample_subtitles.json
+++ b/Tests/OpenImmersiveTests/TestAssets/sample_subtitles.json
@@ -1,0 +1,46 @@
+{
+  "subtitles": [
+    {
+      "index": 1,
+      "startTime": "00:00:00,000",
+      "endTime": "00:00:03,000",
+      "text": "Welcome to the immersive video experience"
+    },
+    {
+      "index": 2,
+      "startTime": "00:00:03,500",
+      "endTime": "00:00:07,000",
+      "text": "This is a JSON subtitle file"
+    },
+    {
+      "index": 3,
+      "startTime": "00:00:07,500",
+      "endTime": "00:00:11,000",
+      "text": "Testing the caption display system"
+    },
+    {
+      "index": 4,
+      "startTime": "00:00:11,500",
+      "endTime": "00:00:15,000",
+      "text": "Subtitles appear at the bottom of your view"
+    },
+    {
+      "index": 5,
+      "startTime": "00:00:15,500",
+      "endTime": "00:00:19,000",
+      "text": "Tap the CC button to load subtitle files"
+    },
+    {
+      "index": 6,
+      "startTime": "00:00:19,500",
+      "endTime": "00:00:23,000",
+      "text": "Supports multiple subtitle formats"
+    },
+    {
+      "index": 7,
+      "startTime": "00:00:23,500",
+      "endTime": "00:00:27,000",
+      "text": "Enjoy your immersive video!"
+    }
+  ]
+}

--- a/Tests/OpenImmersiveTests/TestAssets/sample_subtitles.lrc
+++ b/Tests/OpenImmersiveTests/TestAssets/sample_subtitles.lrc
@@ -1,0 +1,10 @@
+[ti:Immersive Video Experience]
+[ar:Sample Caption Track]
+[al:Test Assets]
+[00:00.00]Welcome to the immersive video experience
+[00:03.50]This is an LRC subtitle file
+[00:07.50]Testing the caption display system
+[00:11.50]Subtitles appear at the bottom of your view
+[00:15.50]Tap the CC button to load subtitle files
+[00:19.50]Supports multiple subtitle formats
+[00:23.50]Enjoy your immersive video!

--- a/Tests/OpenImmersiveTests/TestAssets/sample_subtitles.srt
+++ b/Tests/OpenImmersiveTests/TestAssets/sample_subtitles.srt
@@ -1,0 +1,27 @@
+1
+00:00:00,000 --> 00:00:03,000
+Welcome to the immersive video experience
+
+2
+00:00:03,500 --> 00:00:07,000
+This is a sample subtitle file
+
+3
+00:00:07,500 --> 00:00:11,000
+Testing the caption display system
+
+4
+00:00:11,500 --> 00:00:15,000
+Subtitles appear at the bottom of your view
+
+5
+00:00:15,500 --> 00:00:19,000
+Tap the CC button to load subtitle files
+
+6
+00:00:19,500 --> 00:00:23,000
+Supports SRT, WebVTT, and other formats
+
+7
+00:00:23,500 --> 00:00:27,000
+Enjoy your immersive video!

--- a/Tests/OpenImmersiveTests/TestAssets/sample_subtitles.ttml
+++ b/Tests/OpenImmersiveTests/TestAssets/sample_subtitles.ttml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tt xmlns="http://www.w3.org/ns/ttml" xml:lang="en">
+  <head>
+    <styling>
+      <style xml:id="s1" tts:textAlign="center" xmlns:tts="http://www.w3.org/ns/ttml#styling"/>
+    </styling>
+    <layout>
+      <region xml:id="bottom" tts:extent="80% 20%" tts:origin="10% 70%" xmlns:tts="http://www.w3.org/ns/ttml#styling"/>
+    </layout>
+  </head>
+  <body>
+    <div>
+      <p begin="00:00:00.000" end="00:00:03.000" region="bottom" style="s1">Welcome to the immersive video experience</p>
+      <p begin="00:00:03.500" end="00:00:07.000" region="bottom" style="s1">This is a TTML subtitle file</p>
+      <p begin="00:00:07.500" end="00:00:11.000" region="bottom" style="s1">Testing the caption display system</p>
+      <p begin="00:00:11.500" end="00:00:15.000" region="bottom" style="s1">Subtitles appear at the bottom of your view</p>
+      <p begin="00:00:15.500" end="00:00:19.000" region="bottom" style="s1">Tap the CC button to load subtitle files</p>
+      <p begin="00:00:19.500" end="00:00:23.000" region="bottom" style="s1">Supports multiple subtitle formats</p>
+      <p begin="00:00:23.500" end="00:00:27.000" region="bottom" style="s1">Enjoy your immersive video!</p>
+    </div>
+  </body>
+</tt>

--- a/Tests/OpenImmersiveTests/TestAssets/sample_subtitles.vtt
+++ b/Tests/OpenImmersiveTests/TestAssets/sample_subtitles.vtt
@@ -1,0 +1,22 @@
+WEBVTT
+
+00:00.000 --> 00:03.000
+Welcome to the immersive video experience
+
+00:03.500 --> 00:07.000
+This is a WebVTT subtitle file
+
+00:07.500 --> 00:11.000
+Testing the caption display system
+
+00:11.500 --> 00:15.000
+Subtitles appear at the bottom of your view
+
+00:15.500 --> 00:19.000
+Tap the CC button to load subtitle files
+
+00:19.500 --> 00:23.000
+Supports SRT, WebVTT, and other formats
+
+00:23.500 --> 00:27.000
+Enjoy your immersive video!


### PR DESCRIPTION
The goal is to introduce basic subtitle / captioning support to the immersive player. So there's logic to parse common formats as well as give a way to enable this in the UI (if made available at initialization).

Changes:

1. Added the SwiftSubtitles dependency and linked it into OpenImmersive so the library can parse subtitles natively (Package.swift:12-30).
2. Introduced a SubtitleParser/SubtitleController duo plus a SubtitleCue model for format-agnostic parsing and fast cue lookup, alongside a SubtitleOverlay view that renders captions with a dark backdrop when VideoPlayer.currentSubtitle is populated 
3. Enhanced VideoPlayer to track configured subtitle URLs, load sidecar files (sync or async), expose visibility toggles, and surface subtitles in the playback loop, while ImmersivePlayer now instantiates the overlay, and keeps it facing the viewer
4. Moved the subtitle toggle into the variant selector/UI stack so captions share the same space as resolution/audio controls
5. Added parser tests that exercise format detection plus sample assets spanning SRT, VTT, ASS, JSON, TTML, and LRC

Flexible Areas:

1. The overlay positioning/orientation and control-panel spacing
2. Variant selector layout, button sizing, and where this toggle lives inside ControlPanel (anything could be reskinned or moved while keeping the underlying bindings intact)