### PR TITLE
Improved frame packing

### DIFF
--- a/Sources/Models/VideoItem.swift
+++ b/Sources/Models/VideoItem.swift
@@ -10,7 +10,7 @@ import AVFoundation
 /// Simple structure describing a video.
 public struct VideoItem: Codable {
     nonisolated
-    public enum Projection: Codable {
+    public enum Projection: Codable, Hashable {
         /// Spherical projection of an equirectangular (or half equirectangular) frame. Use this for mono or MV-HEVC stereo VR180 & VR360 video.
         /// - Parameters:
         ///   - fieldOfView: the horizontal field of view of the video, in degrees.
@@ -23,13 +23,19 @@ public struct VideoItem: Codable {
     }
     
     nonisolated
-    public enum FramePacking: Codable {
+    public enum FramePacking: Codable, Hashable {
         /// The video doesn't use frame packing. Use this for mono and MV-HEVC stereo videos (Spatial, AIV, some APMP).
         case none
         /// Left eye and right eye are packed side-by-side in each video frame. Common with legacy stereo VR180.
-        case sideBySide
+        /// - Parameters:
+        ///   - baseline: the distance between the centers of the lenses of the stereo camera system, in millimeters. The default value is 60.0mm (Canon Dual Fisheye Lens).
+        ///   - horizontalDisparity: the relative horizontal shift of the left and right images, which changes the zero parallax plane, in the uniform range [-1.0...1.0]. The default value is 0.
+        case sideBySide(baseline: Float? = nil, horizontalDisparity: Float? = nil)
         /// Left eye and right eye are packed on top of one another in each video frame. Common with legacy stereo VR360.
-        case overUnder
+        /// - Parameters:
+        ///   - baseline: the distance between the centers of the lenses of the stereo camera system, in millimeters. The default value is 60.0mm (Canon Dual Fisheye Lens).
+        ///   - horizontalDisparity: the relative horizontal shift of the left and right images, which changes the zero parallax plane, in the uniform range [-1.0...1.0]. The default value is 0.   
+        case overUnder(baseline: Float? = nil, horizontalDisparity: Float? = nil)
     }
     
     /// Dictionary of metadata values for the video. `commonIdentifierTitle` and `commonIdentifierDescription` are expected.

--- a/Sources/Models/VideoItem.swift
+++ b/Sources/Models/VideoItem.swift
@@ -76,3 +76,13 @@ extension VideoItem: Equatable {
         lhs.id == rhs.id
     }
 }
+
+public extension VideoItem.FramePacking {
+    /// Left eye and right eye are packed side-by-side in each video frame. Common with legacy stereo VR180.
+    /// Assumes a disparity of 60mm.
+    static let sideBySide: VideoItem.FramePacking = .sideBySide()
+    
+    /// Left eye and right eye are packed on top of one another in each video frame. Common with legacy stereo VR360.
+    /// Assumes a disparity of 60mm.
+    static let overUnder: VideoItem.FramePacking = .overUnder()
+}

--- a/Sources/Models/VideoScreen.swift
+++ b/Sources/Models/VideoScreen.swift
@@ -16,12 +16,6 @@ public class VideoScreen {
     /// Public initializer for visibility.
     public init() {}
     
-    /// The transform to apply to the native VideoPlayerComponent when the projection is a simple rectangle.
-    private static let rectangularScreenTransform = Transform(
-        scale: .init(x: 100, y: 100, z: -100),
-        rotation: .init(),
-        translation: .init(x: 0, y: 0, z: -200))
-    
     /// Updates the video screen mesh with values from a VideoPlayer instance to resize it and start displaying its video media.
     /// - Parameters:
     ///   - videoPlayer: the VideoPlayer instance
@@ -39,7 +33,11 @@ public class VideoScreen {
             }
         
         case .rectangular:
-            self.updateNativePlayer(videoPlayer, transform: Self.rectangularScreenTransform)
+            let rectangularScreenTransform = Transform(
+                scale: .init(x: 1, y: 1, z: -1) * Config.shared.videoScreenRectangleScale,
+                rotation: .init(),
+                translation: .init(x: 0, y: 0, z: -Config.shared.videoScreenRectangleDistance))
+            self.updateNativePlayer(videoPlayer, transform: rectangularScreenTransform)
             
         case .appleImmersive:
             // the Apple Immersive Video entity should always use the identity transform

--- a/Sources/Utils/APMPInjector.swift
+++ b/Sources/Utils/APMPInjector.swift
@@ -15,12 +15,6 @@ public class APMPInjector {
     public enum APMPInjectorError: Error {
         /// The APMPInjector could not be created with framePacking = .none
         case InvalidFramePacking
-        /// Base CMFormatDescription could not be extracted from a pixel buffer.
-        case CreateBaseFormatDescriptionError(status: Int)
-        /// APMP CMFormatDescription could not be created.
-        case CreateAPMPFormatDescriptionError(status: Int)
-        /// APMP CMSampleBuffer could not be created.
-        case CreateAPMPSampleBufferError(status: Int)
     }
     
     /// The renderer to use for enqueueing. Expose this so callers can
@@ -118,64 +112,43 @@ public class APMPInjector {
     private func createAPMPFormatDescription(
         for pixelBuffer: CVPixelBuffer
     ) throws -> CMFormatDescription {
-        var baseFormatDescription: CMFormatDescription?
-        var status = CMVideoFormatDescriptionCreateForImageBuffer(
-            allocator: kCFAllocatorDefault,
-            imageBuffer: pixelBuffer,
-            formatDescriptionOut: &baseFormatDescription
+        let baseFormat = try CMVideoFormatDescription(imageBuffer: pixelBuffer)
+        var extensions = baseFormat.extensions
+        
+        let (packingKind, baseline, disparity): (CMFormatDescription.Extensions.Value.ViewPackingKind, Float?, Float?)
+        (packingKind, baseline, disparity) = switch packing {
+        case .none: (.sideBySide, nil, nil) // unreachable
+        case .sideBySide(let baseline, let horizontalDisparity): (.sideBySide, baseline, horizontalDisparity)
+        case .overUnder(let baseline, let horizontalDisparity): (.overUnder, baseline, horizontalDisparity)
+        }
+        
+        extensions[.viewPackingKind] = .viewPackingKind(packingKind)
+        if let baseline {
+            // multiply by 1000 to go from mm to µm
+            extensions[.stereoCameraBaseline] = .number(UInt32(baseline * 1000))
+        }
+        if let disparity {
+            // clamp from [-1.0, 1.0] and multiply by 10,000 to go in tenths of thousandth of the uniform range
+            extensions[.horizontalDisparityAdjustment] = .number(Int32(min(max(disparity, -1.0), 1.0) * 10000))
+        }
+        
+        let (projectionKind, fieldOfView): (CMFormatDescription.Extensions.Value.ProjectionKind, Float)
+        (projectionKind, fieldOfView) = switch projection {
+        case .equirectangular(let fieldOfView, let _): (fieldOfView > 180 ? .equirectangular : .halfEquirectangular, fieldOfView)
+        case .rectangular: (.rectilinear, 65.0) // hard-coded typical spatial video field of view
+        case .appleImmersive: (.appleImmersiveVideo, 180.0)
+        }
+        
+        extensions[.projectionKind] = .projectionKind(projectionKind)
+        // multiply by 1000 to go from degrees to thousandth of degrees
+        extensions[.horizontalFieldOfView] = .number(UInt32(fieldOfView * 1000))
+        
+        return try CMVideoFormatDescription(
+            videoCodecType: baseFormat.mediaSubType,
+            width: Int(baseFormat.dimensions.width),
+            height: Int(baseFormat.dimensions.height),
+            extensions: extensions
         )
-        
-        guard status == noErr, let baseFormatDescription else {
-            throw APMPInjectorError.CreateBaseFormatDescriptionError(status: Int(status))
-        }
-        
-        // Get existing extensions and add our APMP extensions
-        var extensions: [String: Any] = [:]
-        if let existingExtensions = CMFormatDescriptionGetExtensions(baseFormatDescription) as? [String: Any] {
-            extensions = existingExtensions
-        }
-        
-        let packingValue: CFString = switch packing {
-        case .none: "" as CFString // unreachable
-        case .sideBySide: kCMFormatDescriptionViewPackingKind_SideBySide
-        case .overUnder: kCMFormatDescriptionViewPackingKind_OverUnder
-        }
-        extensions[kCMFormatDescriptionExtension_ViewPackingKind as String] = packingValue
-        
-        let projectionValue: CFString = switch projection {
-        case .equirectangular(let fieldOfView, let _):
-            if fieldOfView > 180 { kCMFormatDescriptionProjectionKind_Equirectangular }
-            else { kCMFormatDescriptionProjectionKind_HalfEquirectangular }
-        case .rectangular: kCMFormatDescriptionProjectionKind_Rectilinear
-        case .appleImmersive: kCMFormatDescriptionProjectionKind_AppleImmersiveVideo
-        }
-        extensions[kCMFormatDescriptionExtension_ProjectionKind as String] = projectionValue
-        
-        let fieldOfView: CFNumber = switch projection {
-        case .equirectangular(let fieldOfView, let _): fieldOfView as CFNumber
-        case .rectangular: 65 as CFNumber
-        case .appleImmersive: 180 as CFNumber
-        }
-        extensions[kCMFormatDescriptionExtension_HorizontalFieldOfView as String] = fieldOfView
-        
-        let dimensions = CMVideoFormatDescriptionGetDimensions(baseFormatDescription)
-        let codecType = CMFormatDescriptionGetMediaSubType(baseFormatDescription)
-        
-        var apmpFormatDescription: CMFormatDescription?
-        status = CMVideoFormatDescriptionCreate(
-            allocator: kCFAllocatorDefault,
-            codecType: codecType,
-            width: dimensions.width,
-            height: dimensions.height,
-            extensions: extensions as CFDictionary,
-            formatDescriptionOut: &apmpFormatDescription
-        )
-        
-        guard status == noErr, let apmpFormatDescription else {
-            throw APMPInjectorError.CreateAPMPFormatDescriptionError(status: Int(status))
-        }
-        
-        return apmpFormatDescription
     }
     
     /// Creates the CoreMedia sample buffer associating a pixel buffer and a video format description.
@@ -191,25 +164,16 @@ public class APMPInjector {
         time: CMTime,
         duration: CMTime
     ) throws -> CMSampleBuffer {
-        var timing = CMSampleTimingInfo(
+        let timing = CMSampleTimingInfo(
             duration: duration,
             presentationTimeStamp: time,
             decodeTimeStamp: .invalid
         )
         
-        var sampleBuffer: CMSampleBuffer?
-        let status = CMSampleBufferCreateReadyWithImageBuffer(
-            allocator: kCFAllocatorDefault,
+        return try CMSampleBuffer(
             imageBuffer: pixelBuffer,
             formatDescription: formatDescription,
-            sampleTiming: &timing,
-            sampleBufferOut: &sampleBuffer
+            sampleTiming: timing
         )
-        
-        guard status == noErr, let sampleBuffer else {
-            throw APMPInjectorError.CreateAPMPSampleBufferError(status: Int(status))
-        }
-        
-        return sampleBuffer
     }
 }

--- a/Sources/Utils/Config.swift
+++ b/Sources/Utils/Config.swift
@@ -32,8 +32,12 @@ public final class Config: Sendable {
     public let controlPanelShowVolume: Bool
     /// Tint for the scrubber (String): RGB or RGBA color in hexadecimal in the #RRGGBB or #RRGGBBAA format.
     public let controlPanelScrubberTint: Color
-    /// Radius of the video screen's sphere in meters (Number): make sure it's large enough to fit the control panel.
+    /// Radius of the spherical video screen in meters (Number): make sure it's large enough to fit the control panel.
     public let videoScreenSphereRadius: Float
+    /// Height of the rectangular video screen in meters (Number).
+    public let videoScreenRectangleScale: Float
+    /// Distance of the rectangular video screen in meters (Number): make sure it's far enough to fit the control panel.
+    public let videoScreenRectangleDistance: Float
     /// Whether to show or hide the Tap Catcher in red (Boolean).
     public let tapCatcherShowDebug: Bool
     
@@ -73,6 +77,8 @@ public final class Config: Sendable {
             controlPanelScrubberTint = .orange.opacity(0.7)
         }
         videoScreenSphereRadius = config["videoScreenSphereRadius"] as? Float ?? 1000.0
+        videoScreenRectangleScale = config["videoScreenRectangleScale"] as? Float ?? 100.0
+        videoScreenRectangleDistance = config["videoScreenRectangleDistance"] as? Float ?? 200.0
         tapCatcherShowDebug = config["tapCatcherShowDebug"] as? Bool ?? false
     }
     

--- a/Sources/Utils/VideoTools.swift
+++ b/Sources/Utils/VideoTools.swift
@@ -161,8 +161,7 @@ public struct VideoTools {
             return (naturalSize, nil)
         }
         
-        guard let extensions = CMFormatDescriptionGetExtensions(formatDescription) as Dictionary?,
-              let rawHorizontalFieldOfView = extensions[kCMFormatDescriptionExtension_HorizontalFieldOfView] as? UInt32 else {
+        guard let rawHorizontalFieldOfView = formatDescription.extensions[.horizontalFieldOfView] as? UInt32 else {
             print("Could extract video resolution but not field of view: No extensions found in format description.")
             return (naturalSize, nil)
         }


### PR DESCRIPTION
Made videoScreenRectangleScale and videoScreenRectangleDistance configurable through openimmersive.plist

Added baseline and horizontal disparity parameters to frame packing; fixed wrong values being written to the format description's extensions, swapped old C style APIs for modern Swift

Removed redundant error types